### PR TITLE
docs(readme): add Live Demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A real-time collaborative drawing application built with Node.js, Express, and Socket.IO. Multiple users can draw together on a shared canvas in real-time.
 
+## Live Demo
+
+Try it here: [paint.wilbertopachecob.dev](https://paint.wilbertopachecob.dev/)
+
 ## Features
 
 - **Real-time Collaboration**: Multiple users can draw simultaneously


### PR DESCRIPTION
### Summary
Adds a dedicated Live Demo section to the project README, referencing the hosted demo so users can try the app without cloning or running it locally.

### Changes
- README.md: add a new "Live Demo" section with a direct link to the hosted application

### Motivation
- Improve discoverability and onboarding for new users
- Provide a quick way for reviewers and contributors to validate the app behavior
- Align documentation with the current deployment

### Demo
- Live site: https://paint.wilbertopachecob.dev/

### How to verify
1. Open the README on GitHub and locate the "Live Demo" section beneath the introduction
2. Click the link and confirm it opens the deployed app and loads successfully

### Notes
- No server or client runtime code changes in this PR
- No configuration, build, or test changes
- Zero impact on production behavior beyond documentation

### Risks
- Minimal: documentation-only change

### Checklist
- [x] Documentation updated
- [x] Conventional commit message used
- [x] Branch up to date with master
- [x] CI passes (no code changes expected)

### Linked resources
- Live demo: https://paint.wilbertopachecob.dev/